### PR TITLE
Prevent attempting downloads on the first day of a quarter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScrapeSEC"
 uuid = "856806e7-be2f-4540-8165-3a51303b7af0"
 authors = ["tylerjthomas9 <tylerjthomas9@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/download_filings.jl
+++ b/src/download_filings.jl
@@ -231,7 +231,7 @@ function download_filings(
     running_tests=false::Bool,
     clean_text::Function=_pass_text,
 )
-    current_date = Dates.now()
+    current_date = Dates.now() - Dates.Day(1) #https://github.com/tylerjthomas9/ScrapeSEC.jl/issues/24
     current_year = Dates.year(current_date)
     current_quarter = Dates.quarterofyear(current_date)
 


### PR DESCRIPTION
Ref https://github.com/tylerjthomas9/ScrapeSEC.jl/issues/24

The SEC does not upload a filing index until the second day of a quarter. Now, we take the quarter as of the previous day to prevent errors when downloading the latest available filings on the first day of a quarter.